### PR TITLE
Implement object annotations

### DIFF
--- a/canvas_test.go
+++ b/canvas_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012 - 2015 The ASCIIToSVG Contributors
+// Copyright 2012 - 2018 The ASCIIToSVG Contributors
 // All rights reserved.
 
 package asciitosvg

--- a/char.go
+++ b/char.go
@@ -1,4 +1,4 @@
-// Copyright 2012 - 2015 The ASCIIToSVG Contributors
+// Copyright 2012 - 2018 The ASCIIToSVG Contributors
 // All rights reserved.
 
 package asciitosvg
@@ -7,9 +7,21 @@ import "unicode"
 
 type char rune
 
+func (c char) isObjectStartTag() bool {
+	return c == '['
+}
+
+func (c char) isObjectEndTag() bool {
+	return c == ']'
+}
+
+func (c char) isTagDefinitionSeparator() bool {
+	return c == ':'
+}
+
 func (c char) isTextStart() bool {
 	r := rune(c)
-	return unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSymbol(r)
+	return c.isObjectStartTag() || unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSymbol(r)
 }
 
 func (c char) isTextCont() bool {

--- a/cmd/a2s/a2s.go
+++ b/cmd/a2s/a2s.go
@@ -1,4 +1,4 @@
-// Copyright 2012 - 2015 The ASCIIToSVG Contributors
+// Copyright 2012 - 2018 The ASCIIToSVG Contributors
 // All rights reserved.
 
 package main
@@ -12,16 +12,19 @@ import (
 	"github.com/asciitosvg/asciitosvg"
 )
 
+const logo = ` .-------------------------.
+ |                         |
+ | .---.-. .-----. .-----. |
+ | | .-. | +-->  | |  <--| |
+ | | '-' | |  <--| +-->  | |
+ | '---'-' '-----' '-----' |
+ |  ascii     2      svg   |
+ |                         |
+ '-------------------------'
 
-const logo = `.-------------------------.
-|                         |
-| .---.-. .-----. .-----. |
-| | .-. | +-->  | |  <--| |
-| | '-' | |  <--| +-->  | |
-| '---'-' '-----' '-----' |
-|  ascii     2      svg   |
-|                         |
-'-------------------------'
+https://github.com/asciitosvg
+
+[1,0]: {"fill":"#88d","a2s:delref":1}
 `
 
 func mainImpl() error {

--- a/svg_test.go
+++ b/svg_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012 - 2015 The ASCIIToSVG Contributors
+// Copyright 2012 - 2018 The ASCIIToSVG Contributors
 // All rights reserved.
 
 package asciitosvg
@@ -12,17 +12,70 @@ import (
 
 func TestCanvasToSVG(t *testing.T) {
 	t.Parallel()
-	data := []string{
-		"+--.",
-		"|Hi:",
-		"+--+",
+	data := []struct {
+		input  []string
+		length int
+	}{
+		// 0 Box with dashed corners and text
+		{
+			[]string{
+				"+--.",
+				"|Hi:",
+				"+--+",
+			},
+			1641,
+		},
+		// 1 Box with non-existent ref
+		{
+			[]string{
+				".-----.",
+				"|[a]  |",
+				"'-----'",
+			},
+			1727,
+		},
+		// 2 Box with ref, change background color of container with #RRGGBB
+		{
+			[]string{
+				".-----.",
+				"|[a]  |",
+				"'-----'",
+				"",
+				"[a]: {\"fill\":\"#000000\"}",
+			},
+			1822,
+		},
+		// 3 Box with ref && fill, change label
+		{
+			[]string{
+				".-----.",
+				"|[a]  |",
+				"'-----'",
+				"",
+				"[a]: {\"fill\":\"#000000\",\"a2s:label\":\"abcdefg\"}",
+			},
+			1790,
+		},
+		// 4 Box with ref && fill && label, remove ref
+		{
+			[]string{
+				".-----.",
+				"|[a]  |",
+				"'-----'",
+				"",
+				"[a]: {\"fill\":\"#000000\",\"a2s:label\":\"abcd\",\"a2s:delref\":1}",
+			},
+			1728,
+		},
 	}
-	canvas, err := NewCanvas([]byte(strings.Join(data, "\n")), 9)
-	if err != nil {
-		t.Fatalf("Error creating canvas: %s", err)
+	for i, line := range data {
+		canvas, err := NewCanvas([]byte(strings.Join(line.input, "\n")), 9)
+		if err != nil {
+			t.Fatalf("Error creating canvas: %s", err)
+		}
+		actual := string(CanvasToSVG(canvas, false, "", 9, 16))
+		// TODO(dhobsd): Use golden file? Worth postponing once output is actually
+		// nice.
+		ut.AssertEqualIndex(t, i, line.length, len(actual))
 	}
-	actual := string(CanvasToSVG(canvas, false, "", 9, 16))
-	// TODO(dhobsd): Use golden file? Worth postponing once output is actually
-	// nice.
-	ut.AssertEqual(t, 1638, len(actual))
 }


### PR DESCRIPTION
This change implements object annotations. These annotations allow users
to "tag" objects with a reference that looks similar to a Markdown link
with reference style. The reference points to a JSON object that
contains options that will be attached to the path of the matching
object. There are two ways to specify a reference.

The first way is to embed a reference inside the object. For example:

```
.------.
|[ref] |
'------'

[ref]: {"fill":"#88d"}
```

The object with the reference `ref` will have the SVG attribute `fill`
set to the value `#88d`. Arbitrary SVG options may be set on the path in
this manner.

By default, both the reference and the label are left in the output.
ASCIIToSVG supports some special attributes; these are attributes
prefixed with `a2s:`. Such attributes will not be inserted into the SVG
path. Currently, two special attributes are implemented: `a2s:label` and
`a2s:delref`.

`a2s:label` changes the text at the point of the label. `a2s:delref`
will remove the reference from rendering if it is set. For example:

```
.------.
|[ref] |
'------'

[ref]: {"fill":"#88d", "a2s:label":"hello", "a2s:delref":1}
```

Will render an SVG containing a box with a background color of `#88d`
and the following un-annotated form:

```
.------.
|hello |
'------'
```

This change also brings in an algorithm to detect the proper color to
use given the contrast of the containing object's fill. This is to
improve accessibility. Objects with a dark fill have white text. Objects
with a light (or no) fill have black text. This currently does not
detect a case where an object has no fill and is logically inside a
containing object with a darker background.

Annotations can also target arbitrary paths. This is intended to be able
to style text and line segments in stable diagrams. An example of such
an annotation is found in the logo in the a2s command.

Tests are added. Copyright years fixed. Unused return values from
io.WriteString are elided entirely.