### PR TITLE
Fix issues with tags and color calculations

### DIFF
--- a/svg_test.go
+++ b/svg_test.go
@@ -23,7 +23,7 @@ func TestCanvasToSVG(t *testing.T) {
 				"|Hi:",
 				"+--+",
 			},
-			1641,
+			1677,
 		},
 		// 1 Box with non-existent ref
 		{
@@ -32,7 +32,7 @@ func TestCanvasToSVG(t *testing.T) {
 				"|[a]  |",
 				"'-----'",
 			},
-			1727,
+			1763,
 		},
 		// 2 Box with ref, change background color of container with #RRGGBB
 		{
@@ -43,7 +43,7 @@ func TestCanvasToSVG(t *testing.T) {
 				"",
 				"[a]: {\"fill\":\"#000000\"}",
 			},
-			1822,
+			1858,
 		},
 		// 3 Box with ref && fill, change label
 		{
@@ -54,7 +54,7 @@ func TestCanvasToSVG(t *testing.T) {
 				"",
 				"[a]: {\"fill\":\"#000000\",\"a2s:label\":\"abcdefg\"}",
 			},
-			1790,
+			1826,
 		},
 		// 4 Box with ref && fill && label, remove ref
 		{
@@ -65,7 +65,7 @@ func TestCanvasToSVG(t *testing.T) {
 				"",
 				"[a]: {\"fill\":\"#000000\",\"a2s:label\":\"abcd\",\"a2s:delref\":1}",
 			},
-			1728,
+			1764,
 		},
 	}
 	for i, line := range data {


### PR DESCRIPTION
I mistakenly implemented the text color calculation only for reference
text. All text needs to have its color chosen based on the background of
its most specific containing object that has a fill. Since users can set
fill to none, we may need to look backwards. If all enclosing polygons
are transparent, the default is for text to be black.

In doing this, I realized that closed paths should have a default fill
as they did in the PHP version. This default fill color is white.
Specifying a default fill provides a consistent view of the SVG
regardless of the background color.