### PR TITLE
Implement ticks and dots; gofmt.

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -38,7 +38,7 @@ func NewCanvas(data []byte, tabWidth int) (Canvas, error) {
 	c := &canvas{
 		options: map[string]map[string]interface{}{
 			"__a2s__closed__options__": map[string]interface{}{
-				"fill": "#fff",
+				"fill":   "#fff",
 				"filter": "url(#dsFilter)",
 			},
 		},

--- a/canvas_test.go
+++ b/canvas_test.go
@@ -13,10 +13,11 @@ import (
 func TestNewCanvas(t *testing.T) {
 	t.Parallel()
 	data := []struct {
-		input   []string
-		strings []string
-		texts   []string
-		corners [][]Point
+		input     []string
+		strings   []string
+		texts     []string
+		points    [][]Point
+		allPoints bool
 	}{
 		// 0 Small box
 		{
@@ -28,6 +29,7 @@ func TestNewCanvas(t *testing.T) {
 			[]string{"Path{[(0,0) (1,0) (2,0) (2,1) (2,2) (1,2) (0,2) (0,1)]}"},
 			[]string{""},
 			[][]Point{{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}},
+			false,
 		},
 
 		// 1 Tight box
@@ -43,6 +45,7 @@ func TestNewCanvas(t *testing.T) {
 					{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1},
 				},
 			},
+			false,
 		},
 
 		// 2 Indented box
@@ -56,6 +59,7 @@ func TestNewCanvas(t *testing.T) {
 			[]string{"Path{[(1,1) (2,1) (3,1) (3,2) (3,3) (2,3) (1,3) (1,2)]}"},
 			[]string{""},
 			[][]Point{{{X: 1, Y: 1}, {X: 3, Y: 1}, {X: 3, Y: 3}, {X: 1, Y: 3}}},
+			false,
 		},
 
 		// 3 Free flow text
@@ -72,6 +76,7 @@ func TestNewCanvas(t *testing.T) {
 				{{X: 0, Y: 2}, {X: 5, Y: 2}},
 				{{X: 9, Y: 2}, {X: 11, Y: 2}},
 			},
+			false,
 		},
 
 		// 4 Text in a box
@@ -87,6 +92,7 @@ func TestNewCanvas(t *testing.T) {
 				{{X: 0, Y: 0}, {X: 3, Y: 0}, {X: 3, Y: 2}, {X: 0, Y: 2}},
 				{{X: 1, Y: 1}, {X: 2, Y: 1}},
 			},
+			false,
 		},
 
 		// 5 Concave pieces
@@ -134,6 +140,7 @@ func TestNewCanvas(t *testing.T) {
 					{X: 4, Y: 18}, {X: 0, Y: 18}, {X: 0, Y: 16}, {X: 4, Y: 16},
 				},
 			},
+			false,
 		},
 
 		// 6 Inner boxes
@@ -156,6 +163,7 @@ func TestNewCanvas(t *testing.T) {
 				{{X: 0, Y: 0}, {X: 6, Y: 0}, {X: 6, Y: 6}, {X: 0, Y: 6}},
 				{{X: 2, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 4}, {X: 2, Y: 4}},
 			},
+			false,
 		},
 
 		// 7 Real world diagram example
@@ -240,6 +248,7 @@ func TestNewCanvas(t *testing.T) {
 				{{X: 15, Y: 18}, {X: 18, Y: 18}},
 				{{X: 13, Y: 23}, {X: 20, Y: 23}},
 			},
+			false,
 		},
 
 		// 8 Interwined lines.
@@ -270,7 +279,9 @@ func TestNewCanvas(t *testing.T) {
 			nil,
 			nil,
 			nil,
+			false,
 		},
+
 		// 9 Indented box
 		{
 			[]string{
@@ -282,7 +293,9 @@ func TestNewCanvas(t *testing.T) {
 			[]string{"Path{[(9,1) (10,1) (11,1) (11,2) (11,3) (10,3) (9,3) (9,2)]}"},
 			[]string{""},
 			[][]Point{{{X: 9, Y: 1}, {X: 11, Y: 1}, {X: 11, Y: 3}, {X: 9, Y: 3}}},
+			false,
 		},
+
 		// 10 Diagonal lines with arrows
 		{
 			[]string{
@@ -296,8 +309,11 @@ func TestNewCanvas(t *testing.T) {
 			[]string{"", ""},
 			[][]Point{
 				{{X: 0, Y: 0, Hint: 2}, {X: 4, Y: 4, Hint: 3}},
-				{{X: 11, Y: 0, Hint: 2}, {X: 7, Y: 4, Hint: 3}}},
+				{{X: 11, Y: 0, Hint: 2}, {X: 7, Y: 4, Hint: 3}},
+			},
+			false,
 		},
+
 		// 11 Diagonal lines forming an object
 		{
 			[]string{
@@ -324,7 +340,9 @@ func TestNewCanvas(t *testing.T) {
 				{X: 0, Y: 6},
 				{X: 0, Y: 3},
 			}},
+			false,
 		},
+
 		// 12 A2S logo
 		{
 			[]string{
@@ -367,6 +385,51 @@ func TestNewCanvas(t *testing.T) {
 				{{X: 13, Y: 6}},
 				{{X: 20, Y: 6}, {X: 22, Y: 6}},
 			},
+			false,
+		},
+
+		// 13 Ticks and dots in lines.
+		{
+			[]string{
+				" ------x----->",
+				"",
+				" <-----o------",
+			},
+			[]string{"Path{[(1,0) (2,0) (3,0) (4,0) (5,0) (6,0) (7,0) (8,0) (9,0) (10,0) (11,0) (12,0) (13,0)]}", "Path{[(1,2) (2,2) (3,2) (4,2) (5,2) (6,2) (7,2) (8,2) (9,2) (10,2) (11,2) (12,2) (13,2)]}"},
+			[]string{"", ""},
+			[][]Point{
+				{
+					{X: 1, Y: 0, Hint: 0},
+					{X: 2, Y: 0, Hint: 0},
+					{X: 3, Y: 0, Hint: 0},
+					{X: 4, Y: 0, Hint: 0},
+					{X: 5, Y: 0, Hint: 0},
+					{X: 6, Y: 0, Hint: 0},
+					{X: 7, Y: 0, Hint: 4},
+					{X: 8, Y: 0, Hint: 0},
+					{X: 9, Y: 0, Hint: 0},
+					{X: 10, Y: 0, Hint: 0},
+					{X: 11, Y: 0, Hint: 0},
+					{X: 12, Y: 0, Hint: 0},
+					{X: 13, Y: 0, Hint: 3},
+				},
+				{
+					{X: 1, Y: 2, Hint: 2},
+					{X: 2, Y: 2, Hint: 0},
+					{X: 3, Y: 2, Hint: 0},
+					{X: 4, Y: 2, Hint: 0},
+					{X: 5, Y: 2, Hint: 0},
+					{X: 6, Y: 2, Hint: 0},
+					{X: 7, Y: 2, Hint: 5},
+					{X: 8, Y: 2, Hint: 0},
+					{X: 9, Y: 2, Hint: 0},
+					{X: 10, Y: 2, Hint: 0},
+					{X: 11, Y: 2, Hint: 0},
+					{X: 12, Y: 2, Hint: 0},
+					{X: 13, Y: 2, Hint: 0},
+				},
+			},
+			true,
 		},
 	}
 	for i, line := range data {
@@ -381,8 +444,12 @@ func TestNewCanvas(t *testing.T) {
 		if line.texts != nil {
 			ut.AssertEqualIndex(t, i, line.texts, getTexts(objs))
 		}
-		if line.corners != nil {
-			ut.AssertEqualIndex(t, i, line.corners, getCorners(objs))
+		if line.points != nil {
+			if line.allPoints == false {
+				ut.AssertEqualIndex(t, i, line.points, getCorners(objs))
+			} else {
+				ut.AssertEqualIndex(t, i, line.points, getPoints(objs))
+			}
 		}
 	}
 }

--- a/char.go
+++ b/char.go
@@ -34,7 +34,7 @@ func (c char) isSpace() bool {
 
 // isPathStart returns true on any form of ascii art that can start a graph.
 func (c char) isPathStart() bool {
-	return c.isCorner() || c.isHorizontal() || c.isVertical() || c.isArrowHorizontalLeft() || c.isArrowVerticalUp() || c.isDiagonal()
+	return (c.isCorner() || c.isHorizontal() || c.isVertical() || c.isArrowHorizontalLeft() || c.isArrowVerticalUp() || c.isDiagonal()) && !c.isTick() && !c.isDot()
 }
 
 func (c char) isCorner() bool {
@@ -50,7 +50,7 @@ func (c char) isDashedHorizontal() bool {
 }
 
 func (c char) isHorizontal() bool {
-	return c.isDashedHorizontal() || c == '-'
+	return c.isDashedHorizontal() || c.isTick() || c.isDot() || c == '-'
 }
 
 func (c char) isDashedVertical() bool {
@@ -58,7 +58,7 @@ func (c char) isDashedVertical() bool {
 }
 
 func (c char) isVertical() bool {
-	return c.isDashedVertical() || c == '|'
+	return c.isDashedVertical() || c.isTick() || c.isDot() || c == '|'
 }
 
 func (c char) isDashed() bool {

--- a/svg.go
+++ b/svg.go
@@ -27,6 +27,10 @@ const (
 	textGroupTag = "  <g id=\"text\" stroke=\"none\" style=\"font-family:%s;font-size:15.2px\" >\n"
 	textTag      = "    <text id=\"obj%d\" x=\"%g\" y=\"%g\" fill=\"%s\">%s</text>\n"
 
+	// Point effect tags.
+	dotTag  = "    <circle cx=\"%g\" cy=\"%g\" r=\"3\" fill=\"#000\" />\n"
+	tickTag = "    <line x1=\"%g\" y1=\"%g\" x2=\"%g\" y2=\"%g\" stroke-width=\"1\" />\n"
+
 	// TODO(dhobsd): Fine tune.
 	blurDef = `  <defs>
     <filter id="dsFilter" width="150%%" height="150%%">
@@ -126,6 +130,30 @@ func CanvasToSVG(c Canvas, noBlur bool, font string, scaleX, scaleY int) []byte 
 			if points[len(points)-1].Hint == EndMarker {
 				opts += pathMarkEnd
 			}
+
+			for _, p := range points {
+				switch p.Hint {
+				case Dot:
+					sp := scale(p, scaleX, scaleY)
+					fmt.Fprintf(b, dotTag, sp.X, sp.Y)
+				case Tick:
+					p := scale(p, scaleX, scaleY)
+					p1, p2 := p, p
+					p1.X -= 4
+					p1.Y -= 4
+					p2.X += 4
+					p2.Y += 4
+					fmt.Fprintf(b, tickTag, p1.X, p1.Y, p2.X, p2.Y)
+
+					p1, p2 = p, p
+					p1.X += 4
+					p1.Y -= 4
+					p2.X -= 4
+					p2.Y += 4
+					fmt.Fprintf(b, tickTag, p1.X, p1.Y, p2.X, p2.Y)
+				}
+			}
+
 			opts += getOpts(obj.Tag())
 			fmt.Fprintf(b, pathTag, "open", i, opts, flatten(points, scaleX, scaleY))
 		}

--- a/svg_test.go
+++ b/svg_test.go
@@ -25,6 +25,7 @@ func TestCanvasToSVG(t *testing.T) {
 			},
 			1677,
 		},
+
 		// 1 Box with non-existent ref
 		{
 			[]string{
@@ -34,6 +35,7 @@ func TestCanvasToSVG(t *testing.T) {
 			},
 			1763,
 		},
+
 		// 2 Box with ref, change background color of container with #RRGGBB
 		{
 			[]string{
@@ -45,6 +47,7 @@ func TestCanvasToSVG(t *testing.T) {
 			},
 			1858,
 		},
+
 		// 3 Box with ref && fill, change label
 		{
 			[]string{
@@ -56,6 +59,7 @@ func TestCanvasToSVG(t *testing.T) {
 			},
 			1826,
 		},
+
 		// 4 Box with ref && fill && label, remove ref
 		{
 			[]string{
@@ -66,6 +70,16 @@ func TestCanvasToSVG(t *testing.T) {
 				"[a]: {\"fill\":\"#000000\",\"a2s:label\":\"abcd\",\"a2s:delref\":1}",
 			},
 			1764,
+		},
+
+		// 5 Ticks and dots in lines.
+		{
+			[]string{
+				" ------x----->",
+				"",
+				" <-----o------",
+			},
+			1968,
 		},
 	}
 	for i, line := range data {


### PR DESCRIPTION
Implement support for ticks and dots along a line. Ticks and dots cannot
start a line. (Otherwise things get confusing; any time you see an `x`
or `o` character, you have to look at context to see if it could
possibly be a line, and it probably isn't...)

I should really add a gofmt hook into vim.