### PR TITLE
Delete already-fixed-TODO; fix another.

### DIFF
--- a/object.go
+++ b/object.go
@@ -124,9 +124,10 @@ func (o *object) seal(c *canvas) {
 				o.isDashed = true
 			}
 
-			// TODO(dhobsd): Only do this for corners.
-			if c.at(p).isRoundedCorner() {
-				o.points[i].Hint = RoundedCorner
+			for _, corner := range o.corners {
+				if corner.X == p.X && corner.Y == p.Y && c.at(p).isRoundedCorner() {
+					o.points[i].Hint = RoundedCorner
+				}
 			}
 		}
 		o.text[i] = rune(c.at(p))

--- a/svg.go
+++ b/svg.go
@@ -206,10 +206,7 @@ func CanvasToSVG(c Canvas, noBlur bool, font string, scaleX, scaleY int) []byte 
 
 	for i, obj := range c.Objects() {
 		if obj.IsText() {
-			// Look up the fill of the containing box to determine what text color to
-			// use. TODO(dhobsd): when an object is nested inside a containing object
-			// with a dark fill, we do not detect this properly. We should scan all
-			// containing objects here to find the most specific fill.
+			// Look up the fill of the containing box to determine what text color to use.
 			color, err := findTextColor(obj)
 			if err != nil {
 				fmt.Printf("Error figuring out text color: %s\n", err)


### PR DESCRIPTION
Only apply the rounded corner hint to corners of the box. This has the
side-effect of fixing the stupid logo quirk that actually makes it
(unexpectedly) look like a lowercase 'a'. For years, I've been bugged
that I didn't know why that was happening. Now that I've fixed it, I'm
sad the logo no longer looks as cool.