### PR TITLE
Updated installation instructions to 'go install' instead of 'go get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ ultimately ran into the issues described above. Hence this project.
 
 To get the CLI tool, make sure `$GOPATH/bin` is in your `$PATH`. Run:
 
-    $ go get github.com/asciitosvg/asciitosvg/cmd/a2s
+    $ go install github.com/asciitosvg/asciitosvg/cmd/a2s@latest
     $ a2s -h
      .-------------------------.
      |                         |


### PR DESCRIPTION
Just a minor suggested update to the installation instructions in the readme. When using:
```
go get github.com/asciitosvg/asciitosvg/cmd/a2s
```
I get the message:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```
Following the suggestion, this works for me:
```
go install github.com/asciitosvg/asciitosvg/cmd/a2s@latest
```

This pull request simply updates the instructions in the readme to the second version. Note that there is a reference further down in the readme to `go get` as well:
> To play with the library:
>
>    $ go get github.com/asciitosvg/asciitosvg

I am not sure what the intended outcome is there so I have not updated it. The `go install` command does not work with this path.

Otherwise, wanted to say nice work on this, I'm looking forward to trying it some more!